### PR TITLE
Done the following:

### DIFF
--- a/GeneralSQLReporter.csproj
+++ b/GeneralSQLReporter.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Helpers\GeneralExtensions.cs" />
     <Compile Include="Helpers\SmtpEmailSender.cs" />
     <Compile Include="Helpers\SqlConnectionExtensions.cs" />
+    <Compile Include="Helpers\SqlReportExporter.cs" />
     <Compile Include="Helpers\SqlReportExtensions.cs" />
     <Compile Include="Helpers\SqlRepository.cs" />
     <Compile Include="Helpers\StoredProcedureReportExtensions.cs" />

--- a/Helpers/GeneralExtensions.cs
+++ b/Helpers/GeneralExtensions.cs
@@ -99,7 +99,9 @@
 
             if (parameters.Any())
             {
-                msg += $"{parameters.Count} Parameters:{Environment.NewLine}-----";
+                msg += $"{parameters.Count} Parameters:{Environment.NewLine}" +
+                    "-----" +
+                    $"{Environment.NewLine}";
 
                 parameters.ForEach(p =>
                 {

--- a/Models/GenericReport.cs
+++ b/Models/GenericReport.cs
@@ -33,7 +33,7 @@
         /// <summary>
         /// Gets the <see cref="List{SqlParameter}"/>'s for the Stored Procedure Report
         /// </summary>
-        public List<SqlParameter> Parameters { get; internal set; }
+        public List<SqlParameter> Parameters { get; internal set; } = new List<SqlParameter>();
 
         /// <summary>
         /// The List of Email Addresses that will recieve the Result of the Report via Email over SMTP.

--- a/Models/ReportResultSet.cs
+++ b/Models/ReportResultSet.cs
@@ -83,9 +83,12 @@
             });
 
             //// Remove trailing pipe
-            colString = colString.Trim().Remove(colString.Length - 1, 1).Trim();
+            var trimmedColString = colString.Trim();
+            var lastIndex = trimmedColString.LastIndexOf('|');
+            colString = trimmedColString.Remove(lastIndex, 1).Trim();
+
             baseMsg += $"Columns & Index: {newLine}[{colString}]{newLine}";
-            baseMsg += $"Record Count: {this.Rows.Count:N2}";
+            baseMsg += $"Record Count: {this.Rows.Count:N0}{newLine}";
 
             var typeMsg = repUsed == ReportType.SqlReport ? "Query" : "Stored Procedure";
             baseMsg += $"{typeMsg} Used: {newLine}";

--- a/Models/SqlReport.cs
+++ b/Models/SqlReport.cs
@@ -9,7 +9,7 @@
     /// </summary>
     /// <remarks>
     /// Contains Properties and various constructors for the <see cref="SqlReport"/> class which is used when calling
-    /// <see cref="SqlRepository.RunSingleReport(SqlReport)"/> or <see cref="SqlRepository.RunSingleReportAsync(SqlReport)"/>
+    /// <see cref="SqlRepository.RunSingleReport(GenericReport)"/> or <see cref="SqlRepository.RunSingleReportAsync(GenericReport)"/>
     /// </remarks>
     public class SqlReport : GenericReport
     {


### PR DESCRIPTION
- [#13] - Refactored `SqlRepository` to only require 2 methods for `RunSingleReport` & `RunSingleReportAsync` taking a parameter of `GenericReport`.
- Added a default value of `new List<SqlParameter>` to `Parameters` property on the `GenericReport` to prevent exceptions.
- Updated the `ToString()` overload on the `ReportResultSet` class to better output the Contents to a string.